### PR TITLE
Made '__base' method available for mocking 

### DIFF
--- a/lib/inherit.js
+++ b/lib/inherit.js
@@ -74,14 +74,19 @@ function override(base, res, add) {
                         base[name] :
                         name === '__constructor'? // case of inheritance from plain function
                             res.__self.__parent :
-                            noOp;
-                return function() {
-                    var baseSaved = this.__base;
-                    this.__base = baseMethod;
-                    var res = prop.apply(this, arguments);
-                    this.__base = baseSaved;
-                    return res;
-                };
+                            noOp,
+                    result = function() {
+                        var baseSaved = this.__base;
+
+                        this.__base = result.__base;
+                        var res = prop.apply(this, arguments);
+                        this.__base = baseSaved;
+
+                        return res;
+                    };
+                result.__base = baseMethod;
+
+                return result;
             })(name, prop);
         } else {
             res[name] = prop;

--- a/test/test.js
+++ b/test/test.js
@@ -218,3 +218,23 @@ exports.testFunctionMixinStatic = function(test) {
     test.equal(B.staticMethodM(), 'M');
     test.done();
 };
+
+exports.testBaseMocking = function(test) {
+     var A = inherit({
+            m : function() {
+                return 'A';
+            }
+        }),
+        B = inherit(A, {
+            m : function() {
+                return this.__base() + 'B';
+            }
+        });
+
+     B.prototype.m.__base = function() { return 'C'; };
+
+     var b = new B();
+
+     test.equal(b.m(), 'CB');
+     test.done();
+};


### PR DESCRIPTION
I have two classes
```
     var A = inherit({
            m : function() {
                //some unknown dependencies.
                return 'A';
            }
        })
```

``` 
       var B = inherit(A, {
            m : function() {
                return this.__base() + 'B';
            }
        })
```
And when i want to test 'm' method in class B, i can't mock method 'm' in base class. So for test purpose i need to mock all deependencies that base method 'm' have. It's really inconvenient  and hard to maintain.

this PR is first try to somehow fix this situation.
