### PR TITLE
Copy property descriptors during inheritance

### DIFF
--- a/lib/inherit.js
+++ b/lib/inherit.js
@@ -38,6 +38,14 @@ var hasIntrospection = (function(){'_';}).toString().indexOf('_') > -1,
     },
     noOp = function() {},
     needCheckProps = true,
+    getPropDesc = Object.getOwnPropertyDescriptor || function(obj, p) {
+        return {
+            value: obj[p]
+        };
+    },
+    defProp = Object.defineProperty || function(obj, p, desc) {
+        obj[p] = desc.value;
+    },
     testPropObj = { toString : '' };
 
 for(var i in testPropObj) { // fucking ie hasn't toString, valueOf in for
@@ -61,12 +69,13 @@ function getPropList(obj) {
 function override(base, res, add) {
     var addList = getPropList(add),
         j = 0, len = addList.length,
-        name, prop;
+        name, prop, desc;
     while(j < len) {
         if((name = addList[j++]) === '__self') {
             continue;
         }
-        prop = add[name];
+        desc = getPropDesc(add, name);
+        prop = desc.value;
         if(isFunction(prop) &&
                 (!hasIntrospection || prop.toString().indexOf('.__base') > -1)) {
             res[name] = (function(name, prop) {
@@ -89,7 +98,7 @@ function override(base, res, add) {
                 return result;
             })(name, prop);
         } else {
-            res[name] = prop;
+            defProp(res, name, desc);
         }
     }
 }

--- a/test/test.js
+++ b/test/test.js
@@ -238,3 +238,18 @@ exports.testBaseMocking = function(test) {
      test.equal(b.m(), 'CB');
      test.done();
 };
+
+exports.testGetterThis = function(test) {
+    var A = inherit({}),
+        B = inherit(A, {
+            get property() {
+                this.accessed = true;
+                return 123;
+            }
+        });
+
+    var b = new B();
+    test.equal(b.property, 123);
+    test.equal(b.accessed, true);
+    test.done();
+};


### PR DESCRIPTION
This allows to use ES5 getters referering to `this` in derived
classes.
In ES3 environment properties will just be copied as before, but
in ES5 it will copy whole descriptors, including get/set functions.