### PR TITLE
Add license to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
     "homepage" : "https://github.com/dfilatov/node-inherit",
     "keywords" : ["class", "prototype", "inheritance", "mixins", "static"],
     "author" : "Dmitry Filatov <dfilatov@yandex-team.ru>",
+    "license": "MIT",
     "contributors" : [{
         "name" : "Dmitry Filatov",
         "email" : "dfilatov@yandex-team.ru"


### PR DESCRIPTION
Hi.

Your project doesn't include a license in package.json. `eslint` has a dependency on your project and requires all deps declare their license.