### PR TITLE
Fixes issue with window.modules created as a reference for #modules div on the page

### DIFF
--- a/lib/inherit.js
+++ b/lib/inherit.js
@@ -174,7 +174,7 @@ if(typeof exports === 'object') {
     defineAsGlobal = false;
 }
 
-if(typeof modules === 'object') {
+if(typeof modules === 'object' && typeof modules.define === 'function') {
     modules.define('inherit', function(provide) {
         provide(inherit);
     });


### PR DESCRIPTION
I didn't write a test checking the fix and didn't fix possible similar error with `typeof export`.