### PR TITLE
fixed bug with missing prototype in some functions

### DIFF
--- a/lib/inherit.js
+++ b/lib/inherit.js
@@ -68,7 +68,7 @@ function override(base, res, add) {
         }
         prop = add[name];
         if(isFunction(prop) &&
-                !prop.prototype.__self && // check to prevent wrapping of "class" functions
+                (!prop.prototype || !prop.prototype.__self) && // check to prevent wrapping of "class" functions
                 (!hasIntrospection || prop.toString().indexOf('.__base') > -1)) {
             res[name] = (function(name, prop) {
                 var baseMethod = base[name]?
@@ -124,7 +124,7 @@ function inherit() {
         base = hasBase? withMixins? applyMixins(args[0]) : args[0] : emptyBase,
         props = args[hasBase? 1 : 0] || {},
         staticProps = args[hasBase? 2 : 1],
-        res = props.__constructor || (hasBase && base.prototype.__constructor)?
+        res = props.__constructor || (hasBase && base.prototype && base.prototype.__constructor)?
             function() {
                 return this.__constructor.apply(this, arguments);
             } :


### PR DESCRIPTION
Some functions do not have prototype. 
```js
const a = {
  noPrototype() {}, // no prototype in this function
  hasPrototype: function() {} // this function has prototype
}

```

So in node > 4.0.0 inherit fails on some es6 declared methods.


