### PR TITLE
Update test coverage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules
+coverage

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
 node_modules
 coverage
-package-lock.json
+.DS_Store

--- a/.npmignore
+++ b/.npmignore
@@ -1,3 +1,4 @@
 node_modules
+Makefile
 coverage
-package-lock.json
+test

--- a/.npmignore
+++ b/.npmignore
@@ -2,3 +2,4 @@ node_modules
 Makefile
 coverage
 test
+.DS_Store

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
 test:
-	./node_modules/.bin/nodeunit test
+	./node_modules/.bin/jest
 
 .PHONY: test

--- a/lib/inherit.js
+++ b/lib/inherit.js
@@ -7,8 +7,7 @@
 
 (function(global) {
 
-var hasIntrospection = (function(){return '_';}).toString().indexOf('_') > -1,
-    noop = function() {},
+var noop = function() {},
     hasOwnProperty = Object.prototype.hasOwnProperty,
     objCreate = Object.create || /* istanbul ignore next */function(ptp) {
         var inheritance = function() {};
@@ -69,7 +68,7 @@ function override(base, res, add) {
         prop = add[name];
         if(isFunction(prop) &&
                 (!prop.prototype || !prop.prototype.__self) && // check to prevent wrapping of "class" functions
-                (!hasIntrospection || prop.toString().indexOf('.__base') > -1)) {
+                (prop.toString().indexOf('.__base') > -1)) {
             res[name] = (function(name, prop) {
                 var baseMethod = base[name]?
                         base[name] :
@@ -106,7 +105,7 @@ function applyMixins(mixins, res) {
                 inherit(mixins[0], mixin.prototype, mixin) :
                 inherit(mixins[0], mixin);
     }
-    return res || mixins[0];
+    return res;
 }
 
 /**

--- a/lib/inherit.js
+++ b/lib/inherit.js
@@ -38,7 +38,7 @@ var noop = function() {},
     needCheckProps = true,
     testPropObj = { toString : '' };
 
-for(var i in testPropObj) { // fucking ie hasn't toString, valueOf in for
+for(var i in testPropObj) { // It's a pity ie hasn't toString, valueOf in for
     testPropObj.hasOwnProperty(i) && (needCheckProps = false);
 }
 

--- a/lib/inherit.js
+++ b/lib/inherit.js
@@ -8,14 +8,14 @@
 (function(global) {
 
 var hasIntrospection = (function(){return '_';}).toString().indexOf('_') > -1,
-    emptyBase = function() {},
+    emptyBase = /* istanbul ignore next */function() {},
     hasOwnProperty = Object.prototype.hasOwnProperty,
-    objCreate = Object.create || function(ptp) {
+    objCreate = Object.create || /* istanbul ignore next */function(ptp) {
         var inheritance = function() {};
         inheritance.prototype = ptp;
         return new inheritance();
     },
-    objKeys = Object.keys || function(obj) {
+    objKeys = Object.keys ||/* istanbul ignore next */function(obj) {
         var res = [];
         for(var i in obj) {
             hasOwnProperty.call(obj, i) && res.push(i);
@@ -30,7 +30,7 @@ var hasIntrospection = (function(){return '_';}).toString().indexOf('_') > -1,
         return o1;
     },
     toStr = Object.prototype.toString,
-    isArray = Array.isArray || function(obj) {
+    isArray = Array.isArray ||/* istanbul ignore next */function(obj) {
         return toStr.call(obj) === '[object Array]';
     },
     isFunction = function(obj) {
@@ -44,10 +44,11 @@ for(var i in testPropObj) { // fucking ie hasn't toString, valueOf in for
     testPropObj.hasOwnProperty(i) && (needCheckProps = false);
 }
 
-var specProps = needCheckProps? ['toString', 'valueOf'] : null;
+var specProps = needCheckProps? /* istanbul ignore next */['toString', 'valueOf'] : null;
 
 function getPropList(obj) {
     var res = objKeys(obj);
+    /* istanbul ignore next */
     if(needCheckProps) {
         var specProp, i = 0;
         while(specProp = specProps[i++]) {
@@ -170,25 +171,26 @@ inherit.self = function() {
 };
 
 var defineAsGlobal = true;
+/* istanbul ignore next */
 if(typeof exports === 'object') {
     module.exports = inherit;
     defineAsGlobal = false;
 }
-
+/* istanbul ignore next */
 if(typeof modules === 'object' && typeof modules.define === 'function') {
     modules.define('inherit', function(provide) {
         provide(inherit);
     });
     defineAsGlobal = false;
 }
-
+/* istanbul ignore next */
 if(typeof define === 'function') {
     define(function(require, exports, module) {
         module.exports = inherit;
     });
     defineAsGlobal = false;
 }
-
+/* istanbul ignore next */
 defineAsGlobal && (global.inherit = inherit);
 
 })(this);

--- a/lib/inherit.js
+++ b/lib/inherit.js
@@ -8,7 +8,7 @@
 (function(global) {
 
 var hasIntrospection = (function(){return '_';}).toString().indexOf('_') > -1,
-    emptyBase = /* istanbul ignore next */function() {},
+    noop = function() {},
     hasOwnProperty = Object.prototype.hasOwnProperty,
     objCreate = Object.create || /* istanbul ignore next */function(ptp) {
         var inheritance = function() {};
@@ -36,7 +36,6 @@ var hasIntrospection = (function(){return '_';}).toString().indexOf('_') > -1,
     isFunction = function(obj) {
         return toStr.call(obj) === '[object Function]';
     },
-    noOp = function() {},
     needCheckProps = true,
     testPropObj = { toString : '' };
 
@@ -76,7 +75,7 @@ function override(base, res, add) {
                         base[name] :
                         name === '__constructor'? // case of inheritance from plain function
                             res.__self.__parent :
-                            noOp,
+                            noop,
                     result = function() {
                         var baseSaved = this.__base;
 
@@ -122,7 +121,7 @@ function inherit() {
     var args = arguments,
         withMixins = isArray(args[0]),
         hasBase = withMixins || isFunction(args[0]),
-        base = hasBase? withMixins? applyMixins(args[0]) : args[0] : emptyBase,
+        base = hasBase? withMixins? applyMixins(args[0]) : args[0] : noop,
         props = args[hasBase? 1 : 0] || {},
         staticProps = args[hasBase? 2 : 1],
         res = props.__constructor || (hasBase && base.prototype && base.prototype.__constructor)?

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,2073 @@
+{
+    "name": "inherit",
+    "version": "2.2.6",
+    "lockfileVersion": 1,
+    "dependencies": {
+        "@types/jest": {
+            "version": "19.2.3",
+            "resolved": "https://registry.npmjs.org/@types/jest/-/jest-19.2.3.tgz",
+            "integrity": "sha1-YXSAQOhYmokd/C7B0Wot10SCmA4=",
+            "dev": true
+        },
+        "abab": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/abab/-/abab-1.0.3.tgz",
+            "integrity": "sha1-uB3l9ydOxOdW15fNg08wNkJyTl0=",
+            "dev": true
+        },
+        "acorn": {
+            "version": "4.0.13",
+            "resolved": "https://registry.npmjs.org/acorn/-/acorn-4.0.13.tgz",
+            "integrity": "sha1-EFSVrlNh1pe9GVyCUZLhrX8lN4c=",
+            "dev": true
+        },
+        "acorn-globals": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/acorn-globals/-/acorn-globals-3.1.0.tgz",
+            "integrity": "sha1-/YJw9x+7SZawBPqIDuXUZXOnMb8=",
+            "dev": true
+        },
+        "ajv": {
+            "version": "4.11.8",
+            "resolved": "https://registry.npmjs.org/ajv/-/ajv-4.11.8.tgz",
+            "integrity": "sha1-gv+wKynmYq5TvcIK8VlHcGc5xTY=",
+            "dev": true
+        },
+        "align-text": {
+            "version": "0.1.4",
+            "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
+            "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
+            "dev": true
+        },
+        "amdefine": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz",
+            "integrity": "sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU=",
+            "dev": true
+        },
+        "ansi-escapes": {
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-1.4.0.tgz",
+            "integrity": "sha1-06ioOzGapneTZisT52HHkRQiMG4=",
+            "dev": true
+        },
+        "ansi-regex": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+            "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+            "dev": true
+        },
+        "ansi-styles": {
+            "version": "2.2.1",
+            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+            "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+            "dev": true
+        },
+        "anymatch": {
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-1.3.0.tgz",
+            "integrity": "sha1-o+Uvo5FoyCX/V7AkgSbOWo/5VQc=",
+            "dev": true
+        },
+        "append-transform": {
+            "version": "0.4.0",
+            "resolved": "https://registry.npmjs.org/append-transform/-/append-transform-0.4.0.tgz",
+            "integrity": "sha1-126/jKlNJ24keja61EpLdKthGZE=",
+            "dev": true
+        },
+        "argparse": {
+            "version": "1.0.9",
+            "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.9.tgz",
+            "integrity": "sha1-c9g7wmP4bpf4zE9rrhsOkKfSLIY=",
+            "dev": true
+        },
+        "arr-diff": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
+            "integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
+            "dev": true
+        },
+        "arr-flatten": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.0.3.tgz",
+            "integrity": "sha1-onTthawIhJtr14R8RYB0XcUa37E=",
+            "dev": true
+        },
+        "array-equal": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/array-equal/-/array-equal-1.0.0.tgz",
+            "integrity": "sha1-jCpe8kcv2ep0KwTHenUJO6J1fJM=",
+            "dev": true
+        },
+        "array-unique": {
+            "version": "0.2.1",
+            "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
+            "integrity": "sha1-odl8yvy8JiXMcPrc6zalDFiwGlM=",
+            "dev": true
+        },
+        "arrify": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
+            "integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=",
+            "dev": true
+        },
+        "asn1": {
+            "version": "0.2.3",
+            "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz",
+            "integrity": "sha1-2sh4dxPJlmhJ/IGAd36+nB3fO4Y=",
+            "dev": true
+        },
+        "assert-plus": {
+            "version": "0.2.0",
+            "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz",
+            "integrity": "sha1-104bh+ev/A24qttwIfP+SBAasjQ=",
+            "dev": true
+        },
+        "async": {
+            "version": "2.4.1",
+            "resolved": "https://registry.npmjs.org/async/-/async-2.4.1.tgz",
+            "integrity": "sha1-YqVrJ5yYoR0JhwlqAcw+6463u9c=",
+            "dev": true
+        },
+        "asynckit": {
+            "version": "0.4.0",
+            "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+            "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
+            "dev": true
+        },
+        "aws-sign2": {
+            "version": "0.6.0",
+            "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz",
+            "integrity": "sha1-FDQt0428yU0OW4fXY81jYSwOeU8=",
+            "dev": true
+        },
+        "aws4": {
+            "version": "1.6.0",
+            "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.6.0.tgz",
+            "integrity": "sha1-g+9cqGCysy5KDe7e6MdxudtXRx4=",
+            "dev": true
+        },
+        "babel-code-frame": {
+            "version": "6.22.0",
+            "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.22.0.tgz",
+            "integrity": "sha1-AnYgvuVnqIwyVhV05/0IAdMxGOQ=",
+            "dev": true
+        },
+        "babel-core": {
+            "version": "6.24.1",
+            "resolved": "https://registry.npmjs.org/babel-core/-/babel-core-6.24.1.tgz",
+            "integrity": "sha1-jEKFZNzh4fQfszfsNPTDsCK1rYM=",
+            "dev": true
+        },
+        "babel-generator": {
+            "version": "6.24.1",
+            "resolved": "https://registry.npmjs.org/babel-generator/-/babel-generator-6.24.1.tgz",
+            "integrity": "sha1-5xX0hsWN7SVknYiJRNUqoHxdlJc=",
+            "dev": true
+        },
+        "babel-helpers": {
+            "version": "6.24.1",
+            "resolved": "https://registry.npmjs.org/babel-helpers/-/babel-helpers-6.24.1.tgz",
+            "integrity": "sha1-NHHenK7DiOXIUOWX5Yom3fN2ArI=",
+            "dev": true
+        },
+        "babel-jest": {
+            "version": "20.0.3",
+            "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-20.0.3.tgz",
+            "integrity": "sha1-5KA7E9wQOJ4UD8ZF0J/8TO0wFnE=",
+            "dev": true
+        },
+        "babel-messages": {
+            "version": "6.23.0",
+            "resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.23.0.tgz",
+            "integrity": "sha1-8830cDhYA1sqKVHG7F7fbGLyYw4=",
+            "dev": true
+        },
+        "babel-plugin-istanbul": {
+            "version": "4.1.4",
+            "resolved": "https://registry.npmjs.org/babel-plugin-istanbul/-/babel-plugin-istanbul-4.1.4.tgz",
+            "integrity": "sha1-GN3oS/POMp/d8/QQP66SFFbY5Yc=",
+            "dev": true
+        },
+        "babel-plugin-jest-hoist": {
+            "version": "20.0.3",
+            "resolved": "https://registry.npmjs.org/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-20.0.3.tgz",
+            "integrity": "sha1-r+3IU70/jcNUjqZx++adA8wsF2c=",
+            "dev": true
+        },
+        "babel-preset-jest": {
+            "version": "20.0.3",
+            "resolved": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-20.0.3.tgz",
+            "integrity": "sha1-y6yq3stdaJyh4d4TYOv8ZoYsF4o=",
+            "dev": true
+        },
+        "babel-register": {
+            "version": "6.24.1",
+            "resolved": "https://registry.npmjs.org/babel-register/-/babel-register-6.24.1.tgz",
+            "integrity": "sha1-fhDhOi9xBlvfrVoXh7pFvKbe118=",
+            "dev": true
+        },
+        "babel-runtime": {
+            "version": "6.23.0",
+            "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz",
+            "integrity": "sha1-CpSJ8UTecO+zzkMArM2zKeL8VDs=",
+            "dev": true
+        },
+        "babel-template": {
+            "version": "6.24.1",
+            "resolved": "https://registry.npmjs.org/babel-template/-/babel-template-6.24.1.tgz",
+            "integrity": "sha1-BK5RTx+Ts6JTfyoPYKWkX7gwgzM=",
+            "dev": true
+        },
+        "babel-traverse": {
+            "version": "6.24.1",
+            "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.24.1.tgz",
+            "integrity": "sha1-qzZnP9NW+aCUhlnnszjV/q2zFpU=",
+            "dev": true
+        },
+        "babel-types": {
+            "version": "6.24.1",
+            "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.24.1.tgz",
+            "integrity": "sha1-oTaHncFbNga9oNkMH8dDBML/CXU=",
+            "dev": true
+        },
+        "babylon": {
+            "version": "6.17.1",
+            "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.17.1.tgz",
+            "integrity": "sha1-F/FP3fNhtpWYH+Z5OF5PHAHr2G8=",
+            "dev": true
+        },
+        "balanced-match": {
+            "version": "0.4.2",
+            "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz",
+            "integrity": "sha1-yz8+PHMtwPAe5wtAPzAuYddwmDg=",
+            "dev": true
+        },
+        "bcrypt-pbkdf": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz",
+            "integrity": "sha1-Y7xdy2EzG5K8Bf1SiVPDNGKgb40=",
+            "dev": true,
+            "optional": true
+        },
+        "boom": {
+            "version": "2.10.1",
+            "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
+            "integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
+            "dev": true
+        },
+        "brace-expansion": {
+            "version": "1.1.7",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.7.tgz",
+            "integrity": "sha1-Pv/DxQ4ABTH7cg6v+A8K6O8jz1k=",
+            "dev": true
+        },
+        "braces": {
+            "version": "1.8.5",
+            "resolved": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
+            "integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
+            "dev": true
+        },
+        "browser-resolve": {
+            "version": "1.11.2",
+            "resolved": "https://registry.npmjs.org/browser-resolve/-/browser-resolve-1.11.2.tgz",
+            "integrity": "sha1-j/CbCixCFxihBRwmCzLkj0QpOM4=",
+            "dev": true,
+            "dependencies": {
+                "resolve": {
+                    "version": "1.1.7",
+                    "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz",
+                    "integrity": "sha1-IDEU2CrSxe2ejgQRs5ModeiJ6Xs=",
+                    "dev": true
+                }
+            }
+        },
+        "bser": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/bser/-/bser-2.0.0.tgz",
+            "integrity": "sha1-mseNPtXZFYBP2HrLFYvHlxR6Fxk=",
+            "dev": true
+        },
+        "builtin-modules": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
+            "integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8=",
+            "dev": true
+        },
+        "callsites": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/callsites/-/callsites-2.0.0.tgz",
+            "integrity": "sha1-BuuE8A7qQT2oav/vrL/7Ngk7PFA=",
+            "dev": true
+        },
+        "camelcase": {
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
+            "integrity": "sha1-m7UwTS4LVmmLLHWLCKPqqdqlijk=",
+            "dev": true,
+            "optional": true
+        },
+        "caseless": {
+            "version": "0.12.0",
+            "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
+            "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=",
+            "dev": true
+        },
+        "center-align": {
+            "version": "0.1.3",
+            "resolved": "https://registry.npmjs.org/center-align/-/center-align-0.1.3.tgz",
+            "integrity": "sha1-qg0yYptu6XIgBBHL1EYckHvCt60=",
+            "dev": true,
+            "optional": true
+        },
+        "chalk": {
+            "version": "1.1.3",
+            "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+            "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+            "dev": true
+        },
+        "ci-info": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-1.0.0.tgz",
+            "integrity": "sha1-3FKF8rTiUYIWg2gcOBwziPRuxTQ=",
+            "dev": true
+        },
+        "cliui": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
+            "integrity": "sha1-S0dXYP+AJkx2LDoXGQMukcf+oNE=",
+            "dev": true,
+            "optional": true,
+            "dependencies": {
+                "wordwrap": {
+                    "version": "0.0.2",
+                    "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
+                    "integrity": "sha1-t5Zpu0LstAn4PVg8rVLKF+qhZD8=",
+                    "dev": true,
+                    "optional": true
+                }
+            }
+        },
+        "co": {
+            "version": "4.6.0",
+            "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
+            "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=",
+            "dev": true
+        },
+        "code-point-at": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
+            "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
+            "dev": true
+        },
+        "color-convert": {
+            "version": "1.9.0",
+            "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.0.tgz",
+            "integrity": "sha1-Gsz5fdc5uYO/mU1W/sj5WFNkG3o=",
+            "dev": true
+        },
+        "color-name": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.2.tgz",
+            "integrity": "sha1-XIq3K2S9IhXWF66VWeuxSEdc+Y0=",
+            "dev": true
+        },
+        "combined-stream": {
+            "version": "1.0.5",
+            "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
+            "integrity": "sha1-k4NwpXtKUd6ix3wV1cX9+JUWQAk=",
+            "dev": true
+        },
+        "concat-map": {
+            "version": "0.0.1",
+            "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+            "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+            "dev": true
+        },
+        "content-type-parser": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/content-type-parser/-/content-type-parser-1.0.1.tgz",
+            "integrity": "sha1-w+VpiMU8ZRJ/tG1AMqOpACRv3JQ=",
+            "dev": true
+        },
+        "convert-source-map": {
+            "version": "1.5.0",
+            "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.5.0.tgz",
+            "integrity": "sha1-ms1whRxtXf3ZPZKC5e35SgP/RrU=",
+            "dev": true
+        },
+        "core-js": {
+            "version": "2.4.1",
+            "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.4.1.tgz",
+            "integrity": "sha1-TekR5mew6ukSTjQlS1OupvxhjT4=",
+            "dev": true
+        },
+        "cryptiles": {
+            "version": "2.0.5",
+            "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
+            "integrity": "sha1-O9/s3GCBR8HGcgL6KR59ylnqo7g=",
+            "dev": true
+        },
+        "cssom": {
+            "version": "0.3.2",
+            "resolved": "https://registry.npmjs.org/cssom/-/cssom-0.3.2.tgz",
+            "integrity": "sha1-uANhcMefB6kP8vFuIihAJ6JDhIs=",
+            "dev": true
+        },
+        "cssstyle": {
+            "version": "0.2.37",
+            "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-0.2.37.tgz",
+            "integrity": "sha1-VBCXI0yyUTyDzu06zdwn/yeYfVQ=",
+            "dev": true
+        },
+        "dashdash": {
+            "version": "1.14.1",
+            "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
+            "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
+            "dev": true,
+            "dependencies": {
+                "assert-plus": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+                    "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
+                    "dev": true
+                }
+            }
+        },
+        "debug": {
+            "version": "2.6.8",
+            "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
+            "integrity": "sha1-5zFTHKLt4n0YgiJCfaF4IdaP9Pw=",
+            "dev": true
+        },
+        "decamelize": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+            "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
+            "dev": true
+        },
+        "deep-is": {
+            "version": "0.1.3",
+            "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
+            "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=",
+            "dev": true
+        },
+        "default-require-extensions": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/default-require-extensions/-/default-require-extensions-1.0.0.tgz",
+            "integrity": "sha1-836hXT4T/9m0N9M+GnW1+5eHTLg=",
+            "dev": true
+        },
+        "delayed-stream": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+            "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
+            "dev": true
+        },
+        "detect-indent": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-4.0.0.tgz",
+            "integrity": "sha1-920GQ1LN9Docts5hnE7jqUdd4gg=",
+            "dev": true
+        },
+        "diff": {
+            "version": "3.2.0",
+            "resolved": "https://registry.npmjs.org/diff/-/diff-3.2.0.tgz",
+            "integrity": "sha1-yc45Okt8vQsFinJck98pkCeGj/k=",
+            "dev": true
+        },
+        "ecc-jsbn": {
+            "version": "0.1.1",
+            "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
+            "integrity": "sha1-D8c6ntXw1Tw4GTOYUj735UN3dQU=",
+            "dev": true,
+            "optional": true
+        },
+        "errno": {
+            "version": "0.1.4",
+            "resolved": "https://registry.npmjs.org/errno/-/errno-0.1.4.tgz",
+            "integrity": "sha1-uJbiOp5ei6M4cfyZar02NfyaHH0=",
+            "dev": true
+        },
+        "error-ex": {
+            "version": "1.3.1",
+            "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.1.tgz",
+            "integrity": "sha1-+FWobOYa3E6GIcPNoh56dhLDqNw=",
+            "dev": true
+        },
+        "escape-string-regexp": {
+            "version": "1.0.5",
+            "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+            "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+            "dev": true
+        },
+        "escodegen": {
+            "version": "1.8.1",
+            "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.8.1.tgz",
+            "integrity": "sha1-WltTr0aTEQvrsIZ6o0MN07cKEBg=",
+            "dev": true,
+            "dependencies": {
+                "esprima": {
+                    "version": "2.7.3",
+                    "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.7.3.tgz",
+                    "integrity": "sha1-luO3DVd59q1JzQMmc9HDEnZ7pYE=",
+                    "dev": true
+                },
+                "source-map": {
+                    "version": "0.2.0",
+                    "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.2.0.tgz",
+                    "integrity": "sha1-2rc/vPwrqBm03gO9b26qSBZLP50=",
+                    "dev": true,
+                    "optional": true
+                }
+            }
+        },
+        "esprima": {
+            "version": "3.1.3",
+            "resolved": "https://registry.npmjs.org/esprima/-/esprima-3.1.3.tgz",
+            "integrity": "sha1-/cpRzuYTOJXjyI1TXOSdv/YqRjM=",
+            "dev": true
+        },
+        "estraverse": {
+            "version": "1.9.3",
+            "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-1.9.3.tgz",
+            "integrity": "sha1-r2fy3JIlgkFZUJJgkaQAXSnJu0Q=",
+            "dev": true
+        },
+        "esutils": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
+            "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=",
+            "dev": true
+        },
+        "exec-sh": {
+            "version": "0.2.0",
+            "resolved": "https://registry.npmjs.org/exec-sh/-/exec-sh-0.2.0.tgz",
+            "integrity": "sha1-FPdd4/INKG75MwmbLOUKkDWc7xA=",
+            "dev": true
+        },
+        "expand-brackets": {
+            "version": "0.1.5",
+            "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
+            "integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
+            "dev": true
+        },
+        "expand-range": {
+            "version": "1.8.2",
+            "resolved": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.2.tgz",
+            "integrity": "sha1-opnv/TNf4nIeuujiV+x5ZE/IUzc=",
+            "dev": true
+        },
+        "extend": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz",
+            "integrity": "sha1-p1Xqe8Gt/MWjHOfnYtuq3F5jZEQ=",
+            "dev": true
+        },
+        "extglob": {
+            "version": "0.3.2",
+            "resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
+            "integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
+            "dev": true
+        },
+        "extsprintf": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.0.2.tgz",
+            "integrity": "sha1-4QgOBljjALBilJkMxw4VAiNf1VA=",
+            "dev": true
+        },
+        "fast-levenshtein": {
+            "version": "2.0.6",
+            "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+            "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
+            "dev": true
+        },
+        "fb-watchman": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/fb-watchman/-/fb-watchman-2.0.0.tgz",
+            "integrity": "sha1-VOmr99+i8mzZsWNsWIwa/AXeXVg=",
+            "dev": true
+        },
+        "filename-regex": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/filename-regex/-/filename-regex-2.0.1.tgz",
+            "integrity": "sha1-wcS5vuPglyXdsQa3XB4wH+LxiyY=",
+            "dev": true
+        },
+        "fileset": {
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/fileset/-/fileset-2.0.3.tgz",
+            "integrity": "sha1-jnVIqW08wjJ+5eZ0FocjozO7oqA=",
+            "dev": true
+        },
+        "fill-range": {
+            "version": "2.2.3",
+            "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.3.tgz",
+            "integrity": "sha1-ULd9/X5Gm8dJJHCWNpn+eoSFpyM=",
+            "dev": true
+        },
+        "find-parent-dir": {
+            "version": "0.3.0",
+            "resolved": "https://registry.npmjs.org/find-parent-dir/-/find-parent-dir-0.3.0.tgz",
+            "integrity": "sha1-M8RLQpqysvBkYpnF+fcY83b/jVQ=",
+            "dev": true
+        },
+        "find-up": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
+            "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
+            "dev": true
+        },
+        "for-in": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
+            "integrity": "sha1-gQaNKVqBQuwKxybG4iAMMPttXoA=",
+            "dev": true
+        },
+        "for-own": {
+            "version": "0.1.5",
+            "resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.5.tgz",
+            "integrity": "sha1-UmXGgaTylNq78XyVCbZ2OqhFEM4=",
+            "dev": true
+        },
+        "forever-agent": {
+            "version": "0.6.1",
+            "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
+            "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=",
+            "dev": true
+        },
+        "form-data": {
+            "version": "2.1.4",
+            "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.1.4.tgz",
+            "integrity": "sha1-M8GDrPGTJ27KqYFDpp6Uv+4XUNE=",
+            "dev": true
+        },
+        "fs.realpath": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+            "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+            "dev": true
+        },
+        "get-caller-file": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.2.tgz",
+            "integrity": "sha1-9wLmMSfn4jHBYKgMFVSstw1QR+U=",
+            "dev": true
+        },
+        "getpass": {
+            "version": "0.1.7",
+            "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
+            "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
+            "dev": true,
+            "dependencies": {
+                "assert-plus": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+                    "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
+                    "dev": true
+                }
+            }
+        },
+        "glob": {
+            "version": "7.1.2",
+            "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+            "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+            "dev": true
+        },
+        "glob-base": {
+            "version": "0.3.0",
+            "resolved": "https://registry.npmjs.org/glob-base/-/glob-base-0.3.0.tgz",
+            "integrity": "sha1-27Fk9iIbHAscz4Kuoyi0l98Oo8Q=",
+            "dev": true
+        },
+        "glob-parent": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz",
+            "integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
+            "dev": true
+        },
+        "globals": {
+            "version": "9.17.0",
+            "resolved": "https://registry.npmjs.org/globals/-/globals-9.17.0.tgz",
+            "integrity": "sha1-DAymltm5u2lNLlRwvTd3fKrVAoY=",
+            "dev": true
+        },
+        "graceful-fs": {
+            "version": "4.1.11",
+            "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
+            "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
+            "dev": true
+        },
+        "growly": {
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/growly/-/growly-1.3.0.tgz",
+            "integrity": "sha1-8QdIy+dq+WS3yWyTxrzCivEgwIE=",
+            "dev": true
+        },
+        "handlebars": {
+            "version": "4.0.10",
+            "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.0.10.tgz",
+            "integrity": "sha1-PTDHGLCaPZbyPqTMH0A8TTup/08=",
+            "dev": true,
+            "dependencies": {
+                "async": {
+                    "version": "1.5.2",
+                    "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
+                    "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=",
+                    "dev": true
+                },
+                "source-map": {
+                    "version": "0.4.4",
+                    "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
+                    "integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
+                    "dev": true
+                }
+            }
+        },
+        "har-schema": {
+            "version": "1.0.5",
+            "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-1.0.5.tgz",
+            "integrity": "sha1-0mMTX0MwfALGAq/I/pWXDAFRNp4=",
+            "dev": true
+        },
+        "har-validator": {
+            "version": "4.2.1",
+            "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-4.2.1.tgz",
+            "integrity": "sha1-M0gdDxu/9gDdID11gSpqX7oALio=",
+            "dev": true
+        },
+        "has-ansi": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+            "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
+            "dev": true
+        },
+        "has-flag": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
+            "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo=",
+            "dev": true
+        },
+        "hawk": {
+            "version": "3.1.3",
+            "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
+            "integrity": "sha1-B4REvXwWQLD+VA0sm3PVlnjo4cQ=",
+            "dev": true
+        },
+        "hoek": {
+            "version": "2.16.3",
+            "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
+            "integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0=",
+            "dev": true
+        },
+        "home-or-tmp": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/home-or-tmp/-/home-or-tmp-2.0.0.tgz",
+            "integrity": "sha1-42w/LSyufXRqhX440Y1fMqeILbg=",
+            "dev": true
+        },
+        "hosted-git-info": {
+            "version": "2.4.2",
+            "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.4.2.tgz",
+            "integrity": "sha1-AHa59GonBQbduq6lZJaJdGBhKmc=",
+            "dev": true
+        },
+        "html-encoding-sniffer": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-1.0.1.tgz",
+            "integrity": "sha1-eb96eF6klf5mFl5zQVPzY/9UN9o=",
+            "dev": true
+        },
+        "http-signature": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
+            "integrity": "sha1-33LiZwZs0Kxn+3at+OE0qPvPkb8=",
+            "dev": true
+        },
+        "husky": {
+            "version": "0.13.4",
+            "resolved": "https://registry.npmjs.org/husky/-/husky-0.13.4.tgz",
+            "integrity": "sha1-SHhcUCjeNFKlHEjBLE+UshJKFAc=",
+            "dev": true
+        },
+        "iconv-lite": {
+            "version": "0.4.13",
+            "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.13.tgz",
+            "integrity": "sha1-H4irpKsLFQjoMSrMOTRfNumS4vI=",
+            "dev": true
+        },
+        "inflight": {
+            "version": "1.0.6",
+            "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+            "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+            "dev": true
+        },
+        "inherits": {
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+            "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+            "dev": true
+        },
+        "invariant": {
+            "version": "2.2.2",
+            "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.2.tgz",
+            "integrity": "sha1-nh9WrArNtr8wMwbzOL47IErmA2A=",
+            "dev": true
+        },
+        "invert-kv": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
+            "integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY=",
+            "dev": true
+        },
+        "is-arrayish": {
+            "version": "0.2.1",
+            "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
+            "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
+            "dev": true
+        },
+        "is-buffer": {
+            "version": "1.1.5",
+            "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.5.tgz",
+            "integrity": "sha1-Hzsm72E7IUuIy8ojzGwB2Hlh7sw=",
+            "dev": true
+        },
+        "is-builtin-module": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
+            "integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
+            "dev": true
+        },
+        "is-ci": {
+            "version": "1.0.10",
+            "resolved": "https://registry.npmjs.org/is-ci/-/is-ci-1.0.10.tgz",
+            "integrity": "sha1-9zkzayYyNlBhqdSCcM1WrjNpMY4=",
+            "dev": true
+        },
+        "is-dotfile": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/is-dotfile/-/is-dotfile-1.0.3.tgz",
+            "integrity": "sha1-pqLzL/0t+wT1yiXs0Pa4PPeYoeE=",
+            "dev": true
+        },
+        "is-equal-shallow": {
+            "version": "0.1.3",
+            "resolved": "https://registry.npmjs.org/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz",
+            "integrity": "sha1-IjgJj8Ih3gvPpdnqxMRdY4qhxTQ=",
+            "dev": true
+        },
+        "is-extendable": {
+            "version": "0.1.1",
+            "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
+            "integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik=",
+            "dev": true
+        },
+        "is-extglob": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
+            "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
+            "dev": true
+        },
+        "is-finite": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.2.tgz",
+            "integrity": "sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko=",
+            "dev": true
+        },
+        "is-fullwidth-code-point": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+            "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+            "dev": true
+        },
+        "is-glob": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
+            "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
+            "dev": true
+        },
+        "is-number": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz",
+            "integrity": "sha1-Afy7s5NGOlSPL0ZszhbezknbkI8=",
+            "dev": true
+        },
+        "is-posix-bracket": {
+            "version": "0.1.1",
+            "resolved": "https://registry.npmjs.org/is-posix-bracket/-/is-posix-bracket-0.1.1.tgz",
+            "integrity": "sha1-MzTceXdDaOkvAW5vvAqI9c1ua8Q=",
+            "dev": true
+        },
+        "is-primitive": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/is-primitive/-/is-primitive-2.0.0.tgz",
+            "integrity": "sha1-IHurkWOEmcB7Kt8kCkGochADRXU=",
+            "dev": true
+        },
+        "is-typedarray": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
+            "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
+            "dev": true
+        },
+        "is-utf8": {
+            "version": "0.2.1",
+            "resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz",
+            "integrity": "sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI=",
+            "dev": true
+        },
+        "isarray": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+            "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+            "dev": true
+        },
+        "isexe": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+            "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
+            "dev": true
+        },
+        "isobject": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
+            "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
+            "dev": true
+        },
+        "isstream": {
+            "version": "0.1.2",
+            "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
+            "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
+            "dev": true
+        },
+        "istanbul-api": {
+            "version": "1.1.9",
+            "resolved": "https://registry.npmjs.org/istanbul-api/-/istanbul-api-1.1.9.tgz",
+            "integrity": "sha512-zV14oa+hjBNP3gJTM/BzNdJpInHKbZ9cLIEwVasuaTUA1ebF9TBOIfcC5SDAE3C11rXxOw3KSimKGMiFz6PpWQ==",
+            "dev": true
+        },
+        "istanbul-lib-coverage": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-1.1.1.tgz",
+            "integrity": "sha512-0+1vDkmzxqJIn5rcoEqapSB4DmPxE31EtI2dF2aCkV5esN9EWHxZ0dwgDClivMXJqE7zaYQxq30hj5L0nlTN5Q==",
+            "dev": true
+        },
+        "istanbul-lib-hook": {
+            "version": "1.0.7",
+            "resolved": "https://registry.npmjs.org/istanbul-lib-hook/-/istanbul-lib-hook-1.0.7.tgz",
+            "integrity": "sha512-3U2HB9y1ZV9UmFlE12Fx+nPtFqIymzrqCksrXujm3NVbAZIJg/RfYgO1XiIa0mbmxTjWpVEVlkIZJ25xVIAfkQ==",
+            "dev": true
+        },
+        "istanbul-lib-instrument": {
+            "version": "1.7.2",
+            "resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-1.7.2.tgz",
+            "integrity": "sha512-lPgUY+Pa5dlq2/l0qs1PJZ54QPSfo+s4+UZdkb2d0hbOyrEIAbUJphBLFjEyXBdeCONgGRADFzs3ojfFtmuwFA==",
+            "dev": true
+        },
+        "istanbul-lib-report": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-1.1.1.tgz",
+            "integrity": "sha512-tvF+YmCmH4thnez6JFX06ujIA19WPa9YUiwjc1uALF2cv5dmE3It8b5I8Ob7FHJ70H9Y5yF+TDkVa/mcADuw1Q==",
+            "dev": true,
+            "dependencies": {
+                "supports-color": {
+                    "version": "3.2.3",
+                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
+                    "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
+                    "dev": true
+                }
+            }
+        },
+        "istanbul-lib-source-maps": {
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-1.2.1.tgz",
+            "integrity": "sha512-mukVvSXCn9JQvdJl8wP/iPhqig0MRtuWuD4ZNKo6vB2Ik//AmhAKe3QnPN02dmkRe3lTudFk3rzoHhwU4hb94w==",
+            "dev": true
+        },
+        "istanbul-reports": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-1.1.1.tgz",
+            "integrity": "sha512-P8G873A0kW24XRlxHVGhMJBhQ8gWAec+dae7ZxOBzxT4w+a9ATSPvRVK3LB1RAJ9S8bg2tOyWHAGW40Zd2dKfw==",
+            "dev": true
+        },
+        "jest": {
+            "version": "20.0.4",
+            "resolved": "https://registry.npmjs.org/jest/-/jest-20.0.4.tgz",
+            "integrity": "sha1-PdJgwpidba1nix6cxNkZRPbWAqw=",
+            "dev": true,
+            "dependencies": {
+                "jest-cli": {
+                    "version": "20.0.4",
+                    "resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-20.0.4.tgz",
+                    "integrity": "sha1-5TKxnYiuW8bEF+iwWTpv6VSx3JM=",
+                    "dev": true
+                }
+            }
+        },
+        "jest-changed-files": {
+            "version": "20.0.3",
+            "resolved": "https://registry.npmjs.org/jest-changed-files/-/jest-changed-files-20.0.3.tgz",
+            "integrity": "sha1-k5TVzGXEOEBhSb7xv01Sto4D4/g=",
+            "dev": true
+        },
+        "jest-config": {
+            "version": "20.0.4",
+            "resolved": "https://registry.npmjs.org/jest-config/-/jest-config-20.0.4.tgz",
+            "integrity": "sha1-43kwqyIXyRNgXv8T5712PsSPruo=",
+            "dev": true
+        },
+        "jest-diff": {
+            "version": "20.0.3",
+            "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-20.0.3.tgz",
+            "integrity": "sha1-gfKI/Z5nXw+yPHXxwrGURf5YZhc=",
+            "dev": true
+        },
+        "jest-docblock": {
+            "version": "20.0.3",
+            "resolved": "https://registry.npmjs.org/jest-docblock/-/jest-docblock-20.0.3.tgz",
+            "integrity": "sha1-F76phDQswz2DxQ++FUXqDvqkRxI=",
+            "dev": true
+        },
+        "jest-environment-jsdom": {
+            "version": "20.0.3",
+            "resolved": "https://registry.npmjs.org/jest-environment-jsdom/-/jest-environment-jsdom-20.0.3.tgz",
+            "integrity": "sha1-BIqKwS7iJfcZBBdxODS7mZeH3pk=",
+            "dev": true
+        },
+        "jest-environment-node": {
+            "version": "20.0.3",
+            "resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-20.0.3.tgz",
+            "integrity": "sha1-1Ii8RhKvLCRumG6K52caCZFj1AM=",
+            "dev": true
+        },
+        "jest-haste-map": {
+            "version": "20.0.4",
+            "resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-20.0.4.tgz",
+            "integrity": "sha1-ZT61XIic48Ah97lGk/IKQVm63wM=",
+            "dev": true
+        },
+        "jest-jasmine2": {
+            "version": "20.0.4",
+            "resolved": "https://registry.npmjs.org/jest-jasmine2/-/jest-jasmine2-20.0.4.tgz",
+            "integrity": "sha1-/MWxQReA2RHQQpAu8YWehS5g1eE=",
+            "dev": true
+        },
+        "jest-matcher-utils": {
+            "version": "20.0.3",
+            "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-20.0.3.tgz",
+            "integrity": "sha1-s6a443yld4A7CDKpixZPRLeBVhI=",
+            "dev": true
+        },
+        "jest-matchers": {
+            "version": "20.0.3",
+            "resolved": "https://registry.npmjs.org/jest-matchers/-/jest-matchers-20.0.3.tgz",
+            "integrity": "sha1-ymnbHDLbWm9wf6XgQBq7VXAN/WA=",
+            "dev": true
+        },
+        "jest-message-util": {
+            "version": "20.0.3",
+            "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-20.0.3.tgz",
+            "integrity": "sha1-auwoRDBvyw5udNV5bBAG2W/dgxw=",
+            "dev": true
+        },
+        "jest-mock": {
+            "version": "20.0.3",
+            "resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-20.0.3.tgz",
+            "integrity": "sha1-i8Bw6QQUqhVcEajWTIaaDVxx2lk=",
+            "dev": true
+        },
+        "jest-regex-util": {
+            "version": "20.0.3",
+            "resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-20.0.3.tgz",
+            "integrity": "sha1-hburXRM+RGJbGfr4xqpRItCF12I=",
+            "dev": true
+        },
+        "jest-resolve": {
+            "version": "20.0.4",
+            "resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-20.0.4.tgz",
+            "integrity": "sha1-lEiz6La6/BVHlETGSZBFt//ll6U=",
+            "dev": true
+        },
+        "jest-resolve-dependencies": {
+            "version": "20.0.3",
+            "resolved": "https://registry.npmjs.org/jest-resolve-dependencies/-/jest-resolve-dependencies-20.0.3.tgz",
+            "integrity": "sha1-bhSntxevDyyzZnxUneQK8Bexcjo=",
+            "dev": true
+        },
+        "jest-runtime": {
+            "version": "20.0.4",
+            "resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-20.0.4.tgz",
+            "integrity": "sha1-osgCIZxCA/dU3xQE5JAYYWnRJNg=",
+            "dev": true,
+            "dependencies": {
+                "strip-bom": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
+                    "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
+                    "dev": true
+                }
+            }
+        },
+        "jest-snapshot": {
+            "version": "20.0.3",
+            "resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-20.0.3.tgz",
+            "integrity": "sha1-W4R+GtsaTZCFKn+fElCG4YfHZWY=",
+            "dev": true
+        },
+        "jest-util": {
+            "version": "20.0.3",
+            "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-20.0.3.tgz",
+            "integrity": "sha1-DAf32A2C9OWmfG+LnD/n9lz9Mq0=",
+            "dev": true
+        },
+        "jest-validate": {
+            "version": "20.0.3",
+            "resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-20.0.3.tgz",
+            "integrity": "sha1-0M/R3k9XnymEhJJcKA+PHZTsPKs=",
+            "dev": true
+        },
+        "jodid25519": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/jodid25519/-/jodid25519-1.0.2.tgz",
+            "integrity": "sha1-BtSRIlUJNBlHfUJWM2BuDpB4KWc=",
+            "dev": true,
+            "optional": true
+        },
+        "js-tokens": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.1.tgz",
+            "integrity": "sha1-COnxMkhKLEWjCQfp3E1VZ7fxFNc=",
+            "dev": true
+        },
+        "js-yaml": {
+            "version": "3.8.4",
+            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.8.4.tgz",
+            "integrity": "sha1-UgtFZPhlc7qWZir4Woyvp7S1pvY=",
+            "dev": true
+        },
+        "jsbn": {
+            "version": "0.1.1",
+            "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
+            "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
+            "dev": true,
+            "optional": true
+        },
+        "jsdom": {
+            "version": "9.12.0",
+            "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-9.12.0.tgz",
+            "integrity": "sha1-6MVG//ywbADUgzyoRBD+1/igl9Q=",
+            "dev": true
+        },
+        "jsesc": {
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-1.3.0.tgz",
+            "integrity": "sha1-RsP+yMGJKxKwgz25vHYiF226s0s=",
+            "dev": true
+        },
+        "json-schema": {
+            "version": "0.2.3",
+            "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
+            "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=",
+            "dev": true
+        },
+        "json-stable-stringify": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
+            "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
+            "dev": true
+        },
+        "json-stringify-safe": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+            "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
+            "dev": true
+        },
+        "json5": {
+            "version": "0.5.1",
+            "resolved": "https://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
+            "integrity": "sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE=",
+            "dev": true
+        },
+        "jsonify": {
+            "version": "0.0.0",
+            "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
+            "integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM=",
+            "dev": true
+        },
+        "jsprim": {
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.0.tgz",
+            "integrity": "sha1-o7h+QCmNjDgFUtjMdiigu5WiKRg=",
+            "dev": true,
+            "dependencies": {
+                "assert-plus": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+                    "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
+                    "dev": true
+                }
+            }
+        },
+        "kind-of": {
+            "version": "3.2.2",
+            "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+            "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+            "dev": true
+        },
+        "lazy-cache": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.4.tgz",
+            "integrity": "sha1-odePw6UEdMuAhF07O24dpJpEbo4=",
+            "dev": true,
+            "optional": true
+        },
+        "lcid": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
+            "integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
+            "dev": true
+        },
+        "leven": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/leven/-/leven-2.1.0.tgz",
+            "integrity": "sha1-wuep93IJTe6dNCAq6KzORoeHVYA=",
+            "dev": true
+        },
+        "levn": {
+            "version": "0.3.0",
+            "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
+            "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
+            "dev": true
+        },
+        "load-json-file": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
+            "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
+            "dev": true
+        },
+        "locate-path": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
+            "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
+            "dev": true
+        },
+        "lodash": {
+            "version": "4.17.4",
+            "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
+            "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4=",
+            "dev": true
+        },
+        "longest": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
+            "integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc=",
+            "dev": true
+        },
+        "loose-envify": {
+            "version": "1.3.1",
+            "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz",
+            "integrity": "sha1-0aitM/qc4OcT1l/dCsi3SNR4yEg=",
+            "dev": true
+        },
+        "makeerror": {
+            "version": "1.0.11",
+            "resolved": "https://registry.npmjs.org/makeerror/-/makeerror-1.0.11.tgz",
+            "integrity": "sha1-4BpckQnyr3lmDk6LlYd5AYT1qWw=",
+            "dev": true
+        },
+        "merge": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/merge/-/merge-1.2.0.tgz",
+            "integrity": "sha1-dTHjnUlJwoGma4xabgJl6LBYlNo=",
+            "dev": true
+        },
+        "micromatch": {
+            "version": "2.3.11",
+            "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
+            "integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
+            "dev": true,
+            "dependencies": {
+                "normalize-path": {
+                    "version": "2.1.1",
+                    "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
+                    "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
+                    "dev": true
+                }
+            }
+        },
+        "mime-db": {
+            "version": "1.27.0",
+            "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.27.0.tgz",
+            "integrity": "sha1-gg9XIpa70g7CXtVeW13oaeVDbrE=",
+            "dev": true
+        },
+        "mime-types": {
+            "version": "2.1.15",
+            "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.15.tgz",
+            "integrity": "sha1-pOv1BkCUVpI3uM9wBGd20J/JKu0=",
+            "dev": true
+        },
+        "minimatch": {
+            "version": "3.0.4",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+            "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+            "dev": true
+        },
+        "minimist": {
+            "version": "0.0.8",
+            "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+            "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+            "dev": true
+        },
+        "mkdirp": {
+            "version": "0.5.1",
+            "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+            "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+            "dev": true
+        },
+        "ms": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+            "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+            "dev": true
+        },
+        "natural-compare": {
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
+            "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
+            "dev": true
+        },
+        "node-int64": {
+            "version": "0.4.0",
+            "resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
+            "integrity": "sha1-h6kGXNs1XTGC2PlM4RGIuCXGijs=",
+            "dev": true
+        },
+        "node-notifier": {
+            "version": "5.1.2",
+            "resolved": "https://registry.npmjs.org/node-notifier/-/node-notifier-5.1.2.tgz",
+            "integrity": "sha1-L6nhJgX6EACdRFSdb82KY93g5P8=",
+            "dev": true
+        },
+        "normalize-package-data": {
+            "version": "2.3.8",
+            "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.3.8.tgz",
+            "integrity": "sha1-2Bntoqne29H/pWPqQHHZNngilbs=",
+            "dev": true
+        },
+        "normalize-path": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-1.0.0.tgz",
+            "integrity": "sha1-MtDkcvkf80VwHBWoMRAY07CpA3k=",
+            "dev": true
+        },
+        "number-is-nan": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
+            "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
+            "dev": true
+        },
+        "nwmatcher": {
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/nwmatcher/-/nwmatcher-1.4.0.tgz",
+            "integrity": "sha1-tDiTYhcOfvl5jDx3FtgOvAEG/M8=",
+            "dev": true
+        },
+        "oauth-sign": {
+            "version": "0.8.2",
+            "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
+            "integrity": "sha1-Rqarfwrq2N6unsBWV4C31O/rnUM=",
+            "dev": true
+        },
+        "object-assign": {
+            "version": "4.1.1",
+            "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+            "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
+            "dev": true
+        },
+        "object.omit": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/object.omit/-/object.omit-2.0.1.tgz",
+            "integrity": "sha1-Gpx0SCnznbuFjHbKNXmuKlTr0fo=",
+            "dev": true
+        },
+        "once": {
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+            "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+            "dev": true
+        },
+        "optimist": {
+            "version": "0.6.1",
+            "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
+            "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
+            "dev": true
+        },
+        "optionator": {
+            "version": "0.8.2",
+            "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.2.tgz",
+            "integrity": "sha1-NkxeQJ0/TWMB1sC0wFu6UBgK62Q=",
+            "dev": true,
+            "dependencies": {
+                "wordwrap": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
+                    "integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=",
+                    "dev": true
+                }
+            }
+        },
+        "os-homedir": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
+            "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
+            "dev": true
+        },
+        "os-locale": {
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
+            "integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
+            "dev": true
+        },
+        "os-tmpdir": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+            "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
+            "dev": true
+        },
+        "p-limit": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.1.0.tgz",
+            "integrity": "sha1-sH/y2aXYi+yAYDWJWiurZqJ5iLw=",
+            "dev": true
+        },
+        "p-locate": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
+            "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
+            "dev": true
+        },
+        "p-map": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/p-map/-/p-map-1.1.1.tgz",
+            "integrity": "sha1-BfXkrpegaDcbwqXMhr+9vBnErno=",
+            "dev": true
+        },
+        "parse-glob": {
+            "version": "3.0.4",
+            "resolved": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz",
+            "integrity": "sha1-ssN2z7EfNVE7rdFz7wu246OIORw=",
+            "dev": true
+        },
+        "parse-json": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
+            "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
+            "dev": true
+        },
+        "parse5": {
+            "version": "1.5.1",
+            "resolved": "https://registry.npmjs.org/parse5/-/parse5-1.5.1.tgz",
+            "integrity": "sha1-m387DeMr543CQBsXVzzK8Pb1nZQ=",
+            "dev": true
+        },
+        "path-exists": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
+            "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
+            "dev": true
+        },
+        "path-is-absolute": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+            "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+            "dev": true
+        },
+        "path-parse": {
+            "version": "1.0.5",
+            "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.5.tgz",
+            "integrity": "sha1-PBrfhx6pzWyUMbbqK9dKD/BVxME=",
+            "dev": true
+        },
+        "path-type": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
+            "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
+            "dev": true
+        },
+        "performance-now": {
+            "version": "0.2.0",
+            "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-0.2.0.tgz",
+            "integrity": "sha1-M+8wxcd9TqIcWlOGnZG1bY8lVeU=",
+            "dev": true
+        },
+        "pify": {
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+            "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
+            "dev": true
+        },
+        "pinkie": {
+            "version": "2.0.4",
+            "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
+            "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA=",
+            "dev": true
+        },
+        "pinkie-promise": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
+            "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
+            "dev": true
+        },
+        "prelude-ls": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
+            "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
+            "dev": true
+        },
+        "preserve": {
+            "version": "0.2.0",
+            "resolved": "https://registry.npmjs.org/preserve/-/preserve-0.2.0.tgz",
+            "integrity": "sha1-gV7R9uvGWSb4ZbMQwHE7yzMVzks=",
+            "dev": true
+        },
+        "pretty-format": {
+            "version": "20.0.3",
+            "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-20.0.3.tgz",
+            "integrity": "sha1-Ag41ClYKH+GpjcO+tsz/s4beixQ=",
+            "dev": true,
+            "dependencies": {
+                "ansi-styles": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.0.0.tgz",
+                    "integrity": "sha1-VATpOlRMT+x/BIJil3vr/jFV4ME=",
+                    "dev": true
+                }
+            }
+        },
+        "private": {
+            "version": "0.1.7",
+            "resolved": "https://registry.npmjs.org/private/-/private-0.1.7.tgz",
+            "integrity": "sha1-aM5eih7woju1cMwoU3tTMqumPvE=",
+            "dev": true
+        },
+        "prr": {
+            "version": "0.0.0",
+            "resolved": "https://registry.npmjs.org/prr/-/prr-0.0.0.tgz",
+            "integrity": "sha1-GoS4WQgyVQFBGFPQCB7j+obikmo=",
+            "dev": true
+        },
+        "punycode": {
+            "version": "1.4.1",
+            "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
+            "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
+            "dev": true
+        },
+        "qs": {
+            "version": "6.4.0",
+            "resolved": "https://registry.npmjs.org/qs/-/qs-6.4.0.tgz",
+            "integrity": "sha1-E+JtKK1rD/qpExLNO/cI7TUecjM=",
+            "dev": true
+        },
+        "randomatic": {
+            "version": "1.1.6",
+            "resolved": "https://registry.npmjs.org/randomatic/-/randomatic-1.1.6.tgz",
+            "integrity": "sha1-EQ3Kv/OX6dz/fAeJzMCkmt8exbs=",
+            "dev": true
+        },
+        "read-pkg": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
+            "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
+            "dev": true
+        },
+        "read-pkg-up": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
+            "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
+            "dev": true,
+            "dependencies": {
+                "find-up": {
+                    "version": "1.1.2",
+                    "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
+                    "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
+                    "dev": true
+                },
+                "path-exists": {
+                    "version": "2.1.0",
+                    "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
+                    "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
+                    "dev": true
+                }
+            }
+        },
+        "regenerator-runtime": {
+            "version": "0.10.5",
+            "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz",
+            "integrity": "sha1-M2w+/BIgrc7dosn6tntaeVWjNlg=",
+            "dev": true
+        },
+        "regex-cache": {
+            "version": "0.4.3",
+            "resolved": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.3.tgz",
+            "integrity": "sha1-mxpsNdTQ3871cRrmUejp09cRQUU=",
+            "dev": true
+        },
+        "remove-trailing-separator": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.0.1.tgz",
+            "integrity": "sha1-YV67lq9VlVLUv0BXyENtSGq2PMQ=",
+            "dev": true
+        },
+        "repeat-element": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.2.tgz",
+            "integrity": "sha1-7wiaF40Ug7quTZPrmLT55OEdmQo=",
+            "dev": true
+        },
+        "repeat-string": {
+            "version": "1.6.1",
+            "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
+            "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc=",
+            "dev": true
+        },
+        "repeating": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz",
+            "integrity": "sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo=",
+            "dev": true
+        },
+        "request": {
+            "version": "2.81.0",
+            "resolved": "https://registry.npmjs.org/request/-/request-2.81.0.tgz",
+            "integrity": "sha1-xpKJRqDgbF+Nb4qTM0af/aRimKA=",
+            "dev": true
+        },
+        "require-directory": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+            "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
+            "dev": true
+        },
+        "require-main-filename": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz",
+            "integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE=",
+            "dev": true
+        },
+        "resolve": {
+            "version": "1.3.3",
+            "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.3.3.tgz",
+            "integrity": "sha1-ZVkHw0aahoDcLeOidaj91paR8OU=",
+            "dev": true
+        },
+        "right-align": {
+            "version": "0.1.3",
+            "resolved": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
+            "integrity": "sha1-YTObci/mo1FWiSENJOFMlhSGE+8=",
+            "dev": true,
+            "optional": true
+        },
+        "rimraf": {
+            "version": "2.6.1",
+            "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.1.tgz",
+            "integrity": "sha1-wjOOxkPfeht/5cVPqG9XQopV8z0=",
+            "dev": true
+        },
+        "safe-buffer": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.0.1.tgz",
+            "integrity": "sha1-0mPKVGls2KMGtcplUekt5XkY++c=",
+            "dev": true
+        },
+        "sane": {
+            "version": "1.6.0",
+            "resolved": "https://registry.npmjs.org/sane/-/sane-1.6.0.tgz",
+            "integrity": "sha1-lhDEUjB6E10pwf3+JUcDQYDEZ3U=",
+            "dev": true,
+            "dependencies": {
+                "bser": {
+                    "version": "1.0.2",
+                    "resolved": "https://registry.npmjs.org/bser/-/bser-1.0.2.tgz",
+                    "integrity": "sha1-OBEWlwsqbe6lZG3RXdcnhES1YWk=",
+                    "dev": true
+                },
+                "fb-watchman": {
+                    "version": "1.9.2",
+                    "resolved": "https://registry.npmjs.org/fb-watchman/-/fb-watchman-1.9.2.tgz",
+                    "integrity": "sha1-okz0eCf4LTj7Waaa1wt247auc4M=",
+                    "dev": true
+                },
+                "minimist": {
+                    "version": "1.2.0",
+                    "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+                    "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+                    "dev": true
+                }
+            }
+        },
+        "sax": {
+            "version": "1.2.2",
+            "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.2.tgz",
+            "integrity": "sha1-/YYxojvHgmvvXYcb24c3jJVkeCg=",
+            "dev": true
+        },
+        "semver": {
+            "version": "5.3.0",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
+            "integrity": "sha1-myzl094C0XxgEq0yaqa00M9U+U8=",
+            "dev": true
+        },
+        "set-blocking": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+            "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
+            "dev": true
+        },
+        "shellwords": {
+            "version": "0.1.0",
+            "resolved": "https://registry.npmjs.org/shellwords/-/shellwords-0.1.0.tgz",
+            "integrity": "sha1-Zq/Ue2oSky2Qccv9mKUueFzQuhQ=",
+            "dev": true
+        },
+        "slash": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/slash/-/slash-1.0.0.tgz",
+            "integrity": "sha1-xB8vbDn8FtHNF61LXYlhFK5HDVU=",
+            "dev": true
+        },
+        "sntp": {
+            "version": "1.0.9",
+            "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
+            "integrity": "sha1-ZUEYTMkK7qbG57NeJlkIJEPGYZg=",
+            "dev": true
+        },
+        "source-map": {
+            "version": "0.5.6",
+            "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
+            "integrity": "sha1-dc449SvwczxafwwRjYEzSiu19BI=",
+            "dev": true
+        },
+        "source-map-support": {
+            "version": "0.4.15",
+            "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.4.15.tgz",
+            "integrity": "sha1-AyAt9lwG0r2MfsI2KhkwVv7407E=",
+            "dev": true
+        },
+        "spdx-correct": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-1.0.2.tgz",
+            "integrity": "sha1-SzBz2TP/UfORLwOsVRlJikFQ20A=",
+            "dev": true
+        },
+        "spdx-expression-parse": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-1.0.4.tgz",
+            "integrity": "sha1-m98vIOH0DtRH++JzJmGR/O1RYmw=",
+            "dev": true
+        },
+        "spdx-license-ids": {
+            "version": "1.2.2",
+            "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.2.2.tgz",
+            "integrity": "sha1-yd96NCRZSt5r0RkA1ZZpbcBrrFc=",
+            "dev": true
+        },
+        "sprintf-js": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+            "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
+            "dev": true
+        },
+        "sshpk": {
+            "version": "1.13.0",
+            "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.13.0.tgz",
+            "integrity": "sha1-/yo+T9BEl1Vf7Zezmg/YL6+zozw=",
+            "dev": true,
+            "dependencies": {
+                "assert-plus": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+                    "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
+                    "dev": true
+                }
+            }
+        },
+        "string-length": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/string-length/-/string-length-1.0.1.tgz",
+            "integrity": "sha1-VpcPscOFWOnnC3KL894mmsRa36w=",
+            "dev": true
+        },
+        "string-width": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+            "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+            "dev": true
+        },
+        "stringstream": {
+            "version": "0.0.5",
+            "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
+            "integrity": "sha1-TkhM1N5aC7vuGORjB3EKioFiGHg=",
+            "dev": true
+        },
+        "strip-ansi": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+            "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+            "dev": true
+        },
+        "strip-bom": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
+            "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
+            "dev": true
+        },
+        "supports-color": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+            "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+            "dev": true
+        },
+        "symbol-tree": {
+            "version": "3.2.2",
+            "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.2.tgz",
+            "integrity": "sha1-rifbOPZgp64uHDt9G8KQgZuFGeY=",
+            "dev": true
+        },
+        "test-exclude": {
+            "version": "4.1.1",
+            "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-4.1.1.tgz",
+            "integrity": "sha512-35+Asrsk3XHJDBgf/VRFexPgh3UyETv8IAn/LRTiZjVy6rjPVqdEk8dJcJYBzl1w0XCJM48lvTy8SfEsCWS4nA==",
+            "dev": true
+        },
+        "throat": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/throat/-/throat-3.0.0.tgz",
+            "integrity": "sha1-58ZMhny7OEXxCHdkL3tgBVuOwNY=",
+            "dev": true
+        },
+        "tmpl": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/tmpl/-/tmpl-1.0.4.tgz",
+            "integrity": "sha1-I2QN17QtAEM5ERQIIOXPRA5SHdE=",
+            "dev": true
+        },
+        "to-fast-properties": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.3.tgz",
+            "integrity": "sha1-uDVx+k2MJbguIxsG46MFXeTKGkc=",
+            "dev": true
+        },
+        "tough-cookie": {
+            "version": "2.3.2",
+            "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.2.tgz",
+            "integrity": "sha1-8IH3bkyFcg5sN6X6ztc3FQ2EByo=",
+            "dev": true
+        },
+        "tr46": {
+            "version": "0.0.3",
+            "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+            "integrity": "sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o=",
+            "dev": true
+        },
+        "trim-right": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/trim-right/-/trim-right-1.0.1.tgz",
+            "integrity": "sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM=",
+            "dev": true
+        },
+        "tunnel-agent": {
+            "version": "0.6.0",
+            "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+            "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
+            "dev": true
+        },
+        "tweetnacl": {
+            "version": "0.14.5",
+            "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
+            "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
+            "dev": true,
+            "optional": true
+        },
+        "type-check": {
+            "version": "0.3.2",
+            "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
+            "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
+            "dev": true
+        },
+        "uglify-js": {
+            "version": "2.8.27",
+            "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.8.27.tgz",
+            "integrity": "sha1-R3h/kSsPJC5bmENDvo416V9pTJw=",
+            "dev": true,
+            "optional": true,
+            "dependencies": {
+                "yargs": {
+                    "version": "3.10.0",
+                    "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
+                    "integrity": "sha1-9+572FfdfB0tOMDnTvvWgdFDH9E=",
+                    "dev": true,
+                    "optional": true
+                }
+            }
+        },
+        "uglify-to-browserify": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz",
+            "integrity": "sha1-bgkk1r2mta/jSeOabWMoUKD4grc=",
+            "dev": true,
+            "optional": true
+        },
+        "uuid": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.0.1.tgz",
+            "integrity": "sha1-ZUS7ot/ajBzxfmKaOjBeK7H+5sE=",
+            "dev": true
+        },
+        "validate-npm-package-license": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.1.tgz",
+            "integrity": "sha1-KAS6vnEq0zeUWaz74kdGqywwP7w=",
+            "dev": true
+        },
+        "verror": {
+            "version": "1.3.6",
+            "resolved": "https://registry.npmjs.org/verror/-/verror-1.3.6.tgz",
+            "integrity": "sha1-z/XfEpRtKX0rqu+qJoniW+AcAFw=",
+            "dev": true
+        },
+        "walker": {
+            "version": "1.0.7",
+            "resolved": "https://registry.npmjs.org/walker/-/walker-1.0.7.tgz",
+            "integrity": "sha1-L3+bj9ENZ3JisYqITijRlhjgKPs=",
+            "dev": true
+        },
+        "watch": {
+            "version": "0.10.0",
+            "resolved": "https://registry.npmjs.org/watch/-/watch-0.10.0.tgz",
+            "integrity": "sha1-d3mLLaD5kQ1ZXxrOWwwiWFIfIdw=",
+            "dev": true
+        },
+        "webidl-conversions": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-4.0.1.tgz",
+            "integrity": "sha1-gBWherg+fhsxFjhIas6B2mziBqA=",
+            "dev": true
+        },
+        "whatwg-encoding": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-1.0.1.tgz",
+            "integrity": "sha1-PGxFGhmO567FWx7GHQkgxngBpfQ=",
+            "dev": true
+        },
+        "whatwg-url": {
+            "version": "4.8.0",
+            "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-4.8.0.tgz",
+            "integrity": "sha1-0pgaqRSMHgCkHFphMRZqtGg7vMA=",
+            "dev": true,
+            "dependencies": {
+                "webidl-conversions": {
+                    "version": "3.0.1",
+                    "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+                    "integrity": "sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE=",
+                    "dev": true
+                }
+            }
+        },
+        "which": {
+            "version": "1.2.14",
+            "resolved": "https://registry.npmjs.org/which/-/which-1.2.14.tgz",
+            "integrity": "sha1-mofEN48D6CfOyvGs31bHNsAcFOU=",
+            "dev": true
+        },
+        "which-module": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/which-module/-/which-module-1.0.0.tgz",
+            "integrity": "sha1-u6Y8qGGUiZT/MHc2CJ47lgJsKk8=",
+            "dev": true
+        },
+        "window-size": {
+            "version": "0.1.0",
+            "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz",
+            "integrity": "sha1-VDjNLqk7IC76Ohn+iIeu58lPnJ0=",
+            "dev": true,
+            "optional": true
+        },
+        "wordwrap": {
+            "version": "0.0.3",
+            "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
+            "integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc=",
+            "dev": true
+        },
+        "worker-farm": {
+            "version": "1.3.1",
+            "resolved": "https://registry.npmjs.org/worker-farm/-/worker-farm-1.3.1.tgz",
+            "integrity": "sha1-QzMRK7SbF6oFC4eJXKayys9A5f8=",
+            "dev": true
+        },
+        "wrap-ansi": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
+            "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
+            "dev": true
+        },
+        "wrappy": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+            "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+            "dev": true
+        },
+        "xml-name-validator": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-2.0.1.tgz",
+            "integrity": "sha1-TYuPHszTQZqjYgYb7O9RXh5VljU=",
+            "dev": true
+        },
+        "xtend": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
+            "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68=",
+            "dev": true
+        },
+        "y18n": {
+            "version": "3.2.1",
+            "resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz",
+            "integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE=",
+            "dev": true
+        },
+        "yargs": {
+            "version": "7.1.0",
+            "resolved": "https://registry.npmjs.org/yargs/-/yargs-7.1.0.tgz",
+            "integrity": "sha1-a6MY6xaWFyf10oT46gA+jWFU0Mg=",
+            "dev": true,
+            "dependencies": {
+                "camelcase": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-3.0.0.tgz",
+                    "integrity": "sha1-MvxLn82vhF/N9+c7uXysImHwqwo=",
+                    "dev": true
+                },
+                "cliui": {
+                    "version": "3.2.0",
+                    "resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
+                    "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
+                    "dev": true
+                }
+            }
+        },
+        "yargs-parser": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-5.0.0.tgz",
+            "integrity": "sha1-J17PDX/+Bcd+ZOfIbkzZS/DhIoo=",
+            "dev": true,
+            "dependencies": {
+                "camelcase": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-3.0.0.tgz",
+                    "integrity": "sha1-MvxLn82vhF/N9+c7uXysImHwqwo=",
+                    "dev": true
+                }
+            }
+        }
+    }
+}

--- a/package.json
+++ b/package.json
@@ -17,7 +17,14 @@
     "license": "MIT",
     "dependencies": {},
     "devDependencies": {
-        "nodeunit" : "0.9.1"
+        "@types/jest": "^19.2.3",
+        "husky": "^0.13.4",
+        "jest": "^20.0.4"
+    },
+    "scripts": {
+        "prepush": "npm test",
+        "coverage": "jest --coverage",
+        "test": "jest"
     },
     "main" : "index",
     "enb" : {

--- a/package.json
+++ b/package.json
@@ -1,19 +1,28 @@
 {
-    "name" : "inherit",
-    "version" : "2.2.6",
-    "description" : "Inheritance module for Node.js and browsers",
-    "homepage" : "https://github.com/dfilatov/node-inherit",
-    "keywords" : ["class", "prototype", "inheritance", "mixins", "static"],
-    "author" : "Dmitry Filatov <dfilatov@yandex-team.ru>",
-    "contributors" : [{
-        "name" : "Dmitry Filatov",
-        "email" : "dfilatov@yandex-team.ru"
-    }, {
-        "name" : "Sergey Belov",
-        "email" : "peimei@ya.ru",
-        "url" : "http://github.com/arikon"
-    }],
-    "repository": "dfilatov/node-inherit",
+    "name": "inherit",
+    "version": "2.2.6",
+    "description": "Inheritance module for Node.js and browsers",
+    "homepage": "https://github.com/dfilatov/inherit",
+    "keywords": [
+        "class",
+        "prototype",
+        "inheritance",
+        "mixins",
+        "static"
+    ],
+    "author": "Dmitry Filatov <dfilatov@yandex-team.ru>",
+    "contributors": [
+        {
+            "name": "Dmitry Filatov",
+            "email": "dfilatov@yandex-team.ru"
+        },
+        {
+            "name": "Sergey Belov",
+            "email": "peimei@ya.ru",
+            "url": "http://github.com/arikon"
+        }
+    ],
+    "repository": "https://github.com/dfilatov/inherit.git",
     "license": "MIT",
     "dependencies": {},
     "devDependencies": {
@@ -26,9 +35,9 @@
         "coverage": "jest --coverage",
         "test": "jest"
     },
-    "main" : "index",
-    "enb" : {
-        "sources" : [
+    "main": "index",
+    "enb": {
+        "sources": [
             "lib/inherit.js"
         ]
     }

--- a/test/test.js
+++ b/test/test.js
@@ -1,155 +1,150 @@
-var inherit = require('..');
+const inherit = require('..');
 
-exports.testIsFunction = function(test) {
-    test.equal(typeof inherit, 'function');
-    test.done();
-};
+describe('Base', function () {
+    test('Is Function', function() {
+        expect(typeof inherit).toBe('function');
+    });
+});
 
-exports.testInstanceProperties = function(test) {
-    var A = inherit({
-        __constructor : function(val) {
-            this.prop = val;
-        }
+describe('Instance', function () {
+    test('Instance properties', function() {
+        var A = inherit({
+            __constructor : function(val) {
+                this.prop = val;
+            }
+        });
+        expect(new A('test').prop).toBe('test');
+        expect(new A('other').prop).toBe('other');
     });
 
-    test.equal(new A('test').prop, 'test');
-    test.equal(new A('other').prop, 'other');
-    test.done();
-};
+    test('Instance of', function() {
+        var A = inherit({});
+        var B = inherit(A, {});
+        
+        expect(new A()).toBeInstanceOf(A);
+        expect(new A()).not.toBeInstanceOf(B);
+        expect(new B()).toBeInstanceOf(A);
+        expect(new B()).toBeInstanceOf(B);
+    });
 
-exports.testInstanceOf = function(test) {
-    var A = inherit({}),
-        B = inherit(A, {});
-
-    test.ok(new A() instanceof A);
-    test.ok(!(new A() instanceof B));
-    test.ok(new B() instanceof A);
-    test.ok(new B() instanceof B);
-    test.done();
-};
-
-exports.testInstanceOfConstructorResult = function(test) {
-    var A = inherit({}),
-        B = inherit({
-            __constructor : function(val) {
+    test('Instance of constructor result', function() {
+        var A = inherit({});
+        var B = inherit({
+            __constructor : function() {
                 return new A();
             }
         });
+        
+        expect(new B()).toBeInstanceOf(A);
+    });
+});
 
-    test.ok(new B() instanceof A);
-    test.done();
-};
+describe('Inherit', function () {
+    test('Self', function() {
+        var A = inherit({});
+        var B = inherit(A, {});
 
-exports.testSelf = function(test) {
-    var A = inherit({}),
-        B = inherit(A, {});
+        expect(new A().__self).toBe(A);
+        expect(new B().__self).toBe(B);
+    });   
 
-    test.strictEqual(new A().__self, A);
-    test.strictEqual(new B().__self, B);
-    test.done();
-};
-
-exports.testInherit = function(test) {
-    var A = inherit({
+    test('Base inherit', function() {
+        var A = inherit({
             method1 : function() {
                 return 'A';
             }
-        }),
-        B = inherit(A, {
-            method2 : function() {
+        });
+        var B = inherit(A, {
+            method2 : function () {
                 return 'B';
             }
         });
 
-    test.equal(typeof new A().method2, 'undefined');
-    test.equal(new B().method1(), 'A');
-    test.done();
-};
+        expect(typeof new A().method2).toBe('undefined');
+        expect(new B().method1()).toBe('A');
+    });
 
-exports.testInheritFromPlaneFunction = function(test) {
-    var A = function(val) {
+    test('Inherit from plane function', function() {
+        var A = function(val) {
             this.prop = val;
-        },
-        B = inherit(A, {});
+        };
+        var B = inherit(A, {});
 
-    test.ok(new B() instanceof A);
-    test.equal(new B('val').prop, 'val');
-    test.done();
-};
+        expect(new B()).toBeInstanceOf(A);
+        expect(new B('val').prop).toBe('val');
+    });
 
-exports.testInheritAndBaseCallFromPlaneFunction = function(test) {
-    var A = function(val) {
+    test('Inherit and base call from plane function', function() {
+        var A = function(val) {
             this.prop = val;
-        },
-        B = inherit(A, {
+        };
+        var B = inherit(A, {
             __constructor : function() {
                 this.__base('fromB');
             }
         });
 
-    test.ok(new B() instanceof A);
-    test.equal(new B().prop, 'fromB');
-    test.done();
-};
+        expect(new B()).toBeInstanceOf(A);
+        expect(new B().prop).toBe('fromB');
+    });
 
-exports.testStaticInherit = function(test) {
-    var A = inherit({}, {
+    test('Static inherit', function() {
+        var A = inherit({}, {
             method1 : function() {
                 return 'A';
             }
-        }),
-        B = inherit(A, {}, {
+        });
+        var B = inherit(A, {}, {
             method2 : function() {
                 return 'B';
             }
         });
 
-    test.equal(typeof A.method2, 'undefined');
-    test.equal(B.method1(), 'A');
-    test.done();
-};
+        expect(typeof A.method2).toBe('undefined');
+        expect(B.method1()).toBe('A');
+    });
+});
 
-exports.testOverride = function(test) {
-    var A = inherit({
+describe('Override', function () {
+    test('Override method', function() {
+        var A = inherit({
             method : function() {
                 return 'A';
             }
-        }),
-        B = inherit(A, {
+        });
+        var B = inherit(A, {
             method : function() {
                 return 'B';
             }
         });
 
-    test.equal(new A().method(), 'A');
-    test.equal(new B().method(), 'B');
-    test.done();
-};
+        expect(new A().method()).toBe('A');
+        expect(new B().method()).toBe('B');
+    });
 
-exports.testStaticOverride = function(test) {
-    var A = inherit({}, {
+    test('Override static method', function() {
+        var A = inherit({}, {
             method : function() {
                 return 'A';
             }
-        }),
-        B = inherit(A, {}, {
+        });
+        var B = inherit(A, {}, {
             method : function() {
                 return 'B';
             }
         });
 
-    test.equal(A.method(), 'A');
-    test.equal(B.method(), 'B');
-    test.done();
-};
+        expect(A.method()).toBe('A');
+        expect(B.method()).toBe('B');
+    });
 
-exports.testBase = function(test) {
-    var A = inherit({
+    test('Override base', function() {
+        var A = inherit({
             method1 : function() {
                 return 'A';
             }
-        }),
-        B = inherit(A, {
+        });
+        var B = inherit(A, {
             method1 : function() {
                 return this.__base() + 'B';
             },
@@ -158,83 +153,82 @@ exports.testBase = function(test) {
             }
         });
 
-    test.equal(new B().method1(), 'AB');
-    test.equal(new B().method2(), 'undefinedB2');
-    test.done();
-};
+        expect(new B().method1()).toBe('AB');
+        expect(new B().method2()).toBe('undefinedB2');
+    });
 
-exports.testStaticBase = function(test) {
-    var A = inherit({}, {
+    test('Override static base', function() {
+        var A = inherit({}, {
             staticMethod : function() {
                 return 'A';
             }
-        }),
-        B = inherit(A, {}, {
+        });
+        var B = inherit(A, {}, {
             staticMethod : function() {
                 return this.__base() + 'B';
             }
         });
 
-    test.equal(B.staticMethod(), 'AB');
-    test.done();
-};
+        expect(B.staticMethod()).toBe('AB');
+    });
+});
 
-exports.testObjectMixin = function(test) {
-    var A = inherit(),
-        M = {
+describe('Mixin', function () {
+    test('Object mixin', function () {
+        var A = inherit();
+        var M = {
             methodM : function() {
                 return 'M';
             }
-        },
-        B = inherit([A, M]);
+        };
+        var B = inherit([A, M]);
 
-    test.equal(new B().methodM(), 'M');
-    test.done();
-};
-
-exports.testFunctionMixin = function(test) {
-    var A = inherit(),
-        M = inherit({
+        expect(new B().methodM()).toBe('M');
+    });
+    
+    test('Function mixin', function () {
+        var A = inherit();
+        var M = inherit({
             methodM : function() {
                 return 'M';
             }
-        }),
-        B = inherit([A, M]);
+        });
+        var B = inherit([A, M]);
 
-    test.equal(new B().methodM(), 'M');
-    test.strictEqual(new B().__self, B);
-    test.done();
-};
+        expect(new B().methodM()).toBe('M');
+        expect(new B().__self).toBe(B);
+    });
 
-exports.testFunctionMixinStatic = function(test) {
-    var A = inherit(),
-        M = inherit({}, {
+    test('Function mixin static', function () {
+        var A = inherit();
+        var M = inherit({}, {
             staticMethodM : function() {
                 return 'M';
             }
-        }),
-        B = inherit([A, M]);
+        });
+        var B = inherit([A, M]);
 
-    test.equal(B.staticMethodM(), 'M');
-    test.done();
-};
+        expect(B.staticMethodM()).toBe('M');
+    });
+});
 
-exports.testBaseMocking = function(test) {
-     var A = inherit({
+describe('Mocking', function () {
+    test('Base mocking', function () {
+        var A = inherit({
             m : function() {
                 return 'A';
             }
-        }),
-        B = inherit(A, {
+        });
+        var B = inherit(A, {
             m : function() {
                 return this.__base() + 'B';
             }
         });
 
-     B.prototype.m.__base = function() { return 'C'; };
+        B.prototype.m.__base = function() { return 'C'; };
 
-     var b = new B();
+        var b = new B();
 
-     test.equal(b.m(), 'CB');
-     test.done();
-};
+        expect(b.m()).toBe('CB');
+    });
+});


### PR DESCRIPTION
Основная цель полное тестовое покрытие.
Не получилось получить отчет через `nodeunit`, поэтому мигрировал на `jest`. Плюс думал он поможет полефилы протетировать, сразу не получилось поэтому просто заигнорено, но решение позже нашел. Если это критично можно тоже покрыть, но наверное в этом мало смысла.

Отдельными коммитами фиксы 1, 3, 5 их #26 

Отчет о покрытии:

```bash
 PASS  test/test.js
  Base
    ✓ Is Function (6ms)
  Instance
    ✓ Instance empty (2ms)
    ✓ Instance properties (3ms)
    ✓ Instance of (2ms)
    ✓ Instance of constructor result
    ✓ Instance of self (3ms)
  Inherit
    ✓ Self
    ✓ Base inherit (1ms)
    ✓ Inherit from plane function (1ms)
    ✓ Inherit and base call from plane function (1ms)
    ✓ Static inherit (1ms)
  Override
    ✓ Override method
    ✓ Override static method (1ms)
    ✓ Override base (1ms)
    ✓ Override static base
  Mixin
    ✓ Object mixin (1ms)
    ✓ Function mixin
    ✓ Function mixin static (1ms)
  Mocking
    ✓ Base mocking
  Use cases
    ✓ Example from docs (2ms)
    ✓ Inherited functions with private variables

Test Suites: 1 passed, 1 total
Tests:       21 passed, 21 total
Snapshots:   0 total
Time:        0.787s, estimated 1s
Ran all test suites.
-------------|----------|----------|----------|----------|----------------|
File         |  % Stmts | % Branch |  % Funcs |  % Lines |Uncovered Lines |
-------------|----------|----------|----------|----------|----------------|
All files    |      100 |      100 |      100 |      100 |                |
 inherit     |      100 |      100 |      100 |      100 |                |
  index.js   |      100 |      100 |      100 |      100 |                |
 inherit/lib |      100 |      100 |      100 |      100 |                |
  inherit.js |      100 |      100 |      100 |      100 |                |
-------------|----------|----------|----------|----------|----------------|

Process finished with exit code 0

```