### PR TITLE
Add coverage and update scripts for run tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 node_modules
+coverage
+.nyc_output

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,0 @@
-test:
-	./node_modules/.bin/nodeunit test
-
-.PHONY: test

--- a/package.json
+++ b/package.json
@@ -17,9 +17,17 @@
     "license": "MIT",
     "dependencies": {},
     "devDependencies": {
-        "nodeunit" : "0.9.1"
+        "nyc": "^11.0.1",
+        "coveralls" : "^2.13.1",
+        "nodeunit" : "^0.11.1"
     },
     "main" : "index",
+    "scripts" : {
+        "clean" : "rm -r .nyc_output coverage",
+        "coverage" : "nyc --reporter=text --reporter=html nodeunit; echo; echo 'Open coverage/index.html file in your browser'",
+        "coveralls" : "nyc report --reporter=text-lcov | coveralls",
+        "test" : "nyc nodeunit"
+    },
     "enb" : {
         "sources" : [
             "lib/inherit.js"


### PR DESCRIPTION
Разобрался с отчетами о покрытии для nodeunit, теперь надо решить что оставить это https://github.com/dfilatov/inherit/pull/33 или портировать сюда новые тесты.